### PR TITLE
fix: Correctly load all conversation summaries from IndexedDB

### DIFF
--- a/src/lib/lib.js
+++ b/src/lib/lib.js
@@ -98,6 +98,36 @@ export const saveConversation = (conversation) => {
   });
 };
 
+// Load Conversations
+export const loadConversations = () => {
+  return new Promise((resolve, reject) => {
+    initDB().then(db => {
+      const transaction = db.transaction(STORE_NAME, "readonly");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.getAll(); // Correctly use getAll()
+
+      request.onsuccess = (event) => {
+        const conversations = event.target.result; // This will be an array
+        if (conversations) {
+          resolve(conversations.map(conv => ({ id: conv.id, summary: conv.summary })));
+        } else {
+          resolve([]); // Should not happen with getAll unless store is empty
+        }
+      };
+
+      request.onerror = (event) => {
+        console.error("Error loading conversations:", event.target.error);
+        reject(event.target.error);
+      };
+
+      transaction.onabort = (event) => { // Also good to handle onabort for readonly transactions
+        console.error("Transaction aborted while loading conversations:", event.target.error);
+        reject(event.target.error);
+      };
+    }).catch(reject);
+  });
+};
+
 // Load Conversation History
 export const loadConversationHistory = (id) => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Addresses a critical bug where conversation summaries failed to load due to an error in fetching data from IndexedDB. The error ""DataError: Failed to execute 'get' on 'IDBObjectStore': No key or key range specified"" was occurring because the function responsible for loading all conversation summaries was either missing or incorrectly attempting to use `store.get()` without a key.

This commit includes the following changes:

1.  **Added/Corrected `loadConversations` in `src/lib/lib.js`:**
    *   Ensured the `loadConversations` function exists.
    *   This function now correctly uses `store.getAll()` to retrieve all records from the 'conversations' object store.
    *   The result (an array of conversation objects) is then mapped to extract `{id, summary}` pairs as required by the application store.

This fix ensures that the application can successfully load all conversation summaries at startup, allowing you to see and access your past chats. This resolves the primary console errors you reported.