### PR TITLE
fix: Resolve 'Maximum update depth exceeded' React error

### DIFF
--- a/src/components/assistant/assistantPageStore.js
+++ b/src/components/assistant/assistantPageStore.js
@@ -3,6 +3,7 @@ import {setState} from "../../store/store.js";
 import {
     initDB,
     saveConversation,
+    loadConversations,
     loadConversationHistory,
     generateChatId
 } from "../../lib/lib.js";
@@ -16,6 +17,7 @@ initDB().then(() => {
 }).catch(console.error);
 
 export const assistantPageStore = create((set,get) => ({
+    isStoreInitialized: false, // Added flag
     isChatStarting: false,
     setIsChatStarting: (arg) => setState(set,get,"isChatStarting",arg),
     chatHistory: [],
@@ -157,8 +159,13 @@ export const assistantPageStore = create((set,get) => ({
 
     // Initial store setup logic
     initStore: async () => {
-        // Set isLoading to true at the beginning of initStore
-        set({ isLoading: true });
+        if (get().isStoreInitialized) {
+            // console.log("Store already initialized.");
+            if (get().isLoading) set({isLoading: false});
+            return;
+        }
+        set({ isStoreInitialized: true, isLoading: true }); // Set flag and initial loading
+
         const summaries = await get().fetchConversationSummaries(); // fetchConversationSummaries will set isLoading to false
 
         // Check currentChatId *after* fetching summaries
@@ -187,7 +194,7 @@ export const assistantPageStore = create((set,get) => ({
 // Zustand's `create` function runs synchronously, so `assistantPageStore` is defined.
 // We need to access methods on the store, so we do it after `create`.
 const useStore = assistantPageStore; // Standard way to get the hook
-const storeApi = useStore.getState(); // Get the store API (getState, setState, subscribe)
+// const storeApi = useStore.getState(); // Get the store API (getState, setState, subscribe) // Not needed if initStore is not called here
 
 // Initialize the store after it's fully created
-storeApi.initStore().catch(console.error);
+// storeApi.initStore().catch(console.error); // REMOVE THIS LINE

--- a/src/pages/AssistantPage.jsx
+++ b/src/pages/AssistantPage.jsx
@@ -1,13 +1,17 @@
 import { useState, useEffect, useRef } from "react";
+import { shallow } from 'zustand/shallow';
 import { assistantPageStore } from "../components/assistant/assistantPageStore";
-import conversationHistoryIcon from "../assets/talk-icon.svg";
+import talkIcon from "../assets/talk-icon.svg";
 import { ConversationContainer } from "../components/assistant/ConversationContainer";
 
 export default function AssistantPage() {
-  const { conversationSummaries, currentChatId } = assistantPageStore(state => ({
-    conversationSummaries: state.conversationSummaries,
-    currentChatId: state.currentChatId,
-  }));
+  const { conversationSummaries, currentChatId } = assistantPageStore(
+    state => ({
+      conversationSummaries: state.conversationSummaries,
+      currentChatId: state.currentChatId,
+    }),
+    shallow // Apply shallow equality
+  );
   const { initStore, switchConversation, createNewChat } = assistantPageStore.getState();
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -41,7 +45,7 @@ export default function AssistantPage() {
       <div className="relative mb-4"> {/* Container for icon and dropdown, added margin bottom */}
         <img
           ref={iconRef}
-          src={conversationHistoryIcon}
+          src={talkIcon}
           className="w-6 h-6 cursor-pointer" // Adjusted size
           alt="Chat History"
           onClick={(e) => {


### PR DESCRIPTION
This commit addresses a persistent "Maximum update depth exceeded" error by implementing several key changes to how React components interact with the Zustand store (`assistantPageStore.js`) and how the store initializes.

The primary causes of the loop were related to:
1.  Unnecessary re-renders of components due to new object references from Zustand selectors, even when underlying data hadn't changed.
2.  The store's initialization logic (`initStore`) potentially running multiple times or in a way that could trigger recursive updates under certain conditions.

Fixes Implemented:

1.  **Selector Stability in `AssistantPage.jsx`:**
    *   Applied `shallow` equality (from `zustand/shallow`) to the `assistantPageStore` selector that returns an object (`{ conversationSummaries, currentChatId }`). This prevents component re-renders if these state parts haven't shallowly changed.

2.  **Idempotent Store Initialization in `assistantPageStore.js`:**
    *   Introduced an `isStoreInitialized` flag in the store.
    *   The `initStore` function now checks this flag and exits early if initialization has already occurred, preventing its core logic from running multiple times.

3.  **Centralized Initialization Call:**
    *   Removed the module-level call to `storeApi.initStore()`. Store initialization is now solely triggered by `useEffect` hooks in `Chat.jsx` and `AssistantPage.jsx`, which are configured to run once on mount.

These changes are designed to break the conditions that led to recursive update cycles, ensuring the application remains stable and responsive.