### PR TITLE
Implement survey result submission and add loading overlay

### DIFF
--- a/src/components/LoadingOverlay.jsx
+++ b/src/components/LoadingOverlay.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Loading } from "./Loading.jsx";
+
+export default function LoadingOverlay() {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <Loading />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple `LoadingOverlay` component
- show `LoadingOverlay` during signin
- post survey results to `/user/save_survey_result`
- display `LoadingOverlay` while sending survey data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849b810c5ec832c9c5f4654dd367b3b