### PR TITLE
Add survey check in layout

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -22,6 +22,13 @@ export default function Layout() {
   const profileBox = useRef();
 
   useEffect(() => {
+    const didSurvey = localStorage.getItem("didSurvey");
+    if (!didSurvey) {
+      navigate("/survey");
+    }
+  }, [navigate]);
+
+  useEffect(() => {
     const getProfile = async () => {
       try {
         const accessToken = await checkAuth(navigate);


### PR DESCRIPTION
## Summary
- check `didSurvey` in localStorage when Layout mounts
- redirect to `/survey` page if survey hasn't been completed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6ad25d44832cb0db9993c9f0b2eb