### PR TITLE
Add profile images to chat messages

### DIFF
--- a/src/components/assistant/messages/AssistantMessage.jsx
+++ b/src/components/assistant/messages/AssistantMessage.jsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { RecommendedEvent } from '../../schedule/ChatResponse'; 
-import { checkAuth } from '../../../lib/lib.js'; 
+import { RecommendedEvent } from '../../schedule/ChatResponse';
+import { checkAuth } from '../../../lib/lib.js';
 import ErrorNotification from '../../common/ErrorNotification.jsx';
-import {openIndexedDB,getDataByKeyFromIndexedDB,updateDataToIndexedDB} from '../../../lib/lib.js';
+import { openIndexedDB, getDataByKeyFromIndexedDB, updateDataToIndexedDB } from '../../../lib/lib.js';
+import logo from '../../../assets/logo.svg';
 
 
 export function AssistantMessage({ message }) {
@@ -133,50 +134,53 @@ export function AssistantMessage({ message }) {
         severity="error"
         duration={5000}
       />
-      {/* Error display logic */}
-      {message.data && message.data.error ? (
-        <div className="bg-red-100 text-red-700 p-3 rounded-xl shadow-md max-w-md lg:max-w-lg break-words">
-          <p className="font-bold mb-1">Assistant Error</p>
-          <p>{message.data.error.message || "An unexpected error occurred"}</p>
+      <div className="flex flex-col items-start">
+        <div className="flex items-center gap-x-2 mb-1">
+          <img src={logo} className="w-5 h-5 rounded-full border" alt="Assistant" />
+          <span className="font-semibold text-sm">Solus Assistant</span>
         </div>
-      ) : (
-        // Normal response rendering path
-        <div className="bg-slate-100 text-slate-800 py-2 px-4 rounded-xl shadow-md max-w-md lg:max-w-lg prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none break-words">
-          {useHTML ? (
-            <div ref={assistantHtmlResponseContainerRef} dangerouslySetInnerHTML={{ __html: responseToRender }} />
-          ) : (
-            responseToRender
-          )}
-        {currentRecommendations && currentRecommendations.length > 0 && (
-            <div className="w-full flex flex-col items-start mt-2">
-              <div className="flex w-full items-center justify-between px-1 mb-1">
-                <span className="font-semibold text-xs text-blue-700">
-                  Suggested Events
-                </span>
-                {currentRecommendations.length > 0 && ( // Only show Accept All if there are recommendations
-                  <button
-                    className="text-xs text-blue-700 font-semibold cursor-pointer"
-                    onClick={handleAcceptAll}
-                  >
-                    Accept All
-                  </button>
-                )}
+        {message.data && message.data.error ? (
+          <div className="bg-red-100 text-red-700 p-3 rounded-xl shadow-md max-w-md lg:max-w-lg break-words">
+            <p className="font-bold mb-1">Assistant Error</p>
+            <p>{message.data.error.message || "An unexpected error occurred"}</p>
+          </div>
+        ) : (
+          // Normal response rendering path
+          <div className="bg-slate-100 text-slate-800 py-2 px-4 rounded-xl shadow-md max-w-md lg:max-w-lg prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none break-words">
+            {useHTML ? (
+              <div ref={assistantHtmlResponseContainerRef} dangerouslySetInnerHTML={{ __html: responseToRender }} />
+            ) : (
+              responseToRender
+            )}
+            {currentRecommendations && currentRecommendations.length > 0 && (
+              <div className="w-full flex flex-col items-start mt-2">
+                <div className="flex w-full items-center justify-between px-1 mb-1">
+                  <span className="font-semibold text-xs text-blue-700">Suggested Events</span>
+                  {currentRecommendations.length > 0 && (
+                    <button
+                      className="text-xs text-blue-700 font-semibold cursor-pointer"
+                      onClick={handleAcceptAll}
+                    >
+                      Accept All
+                    </button>
+                  )}
+                </div>
+                <div className="flex flex-col gap-y-2 w-full">
+                  {currentRecommendations.map((recommendation) => (
+                    <RecommendedEvent
+                      key={recommendation.id}
+                      recommendation={recommendation}
+                      handleAccept={handleAccept}
+                      currentRecommendations={currentRecommendations}
+                      setCurrentRecommendations={setCurrentRecommendations}
+                    />
+                  ))}
+                </div>
               </div>
-              <div className="flex flex-col gap-y-2 w-full">
-                {currentRecommendations.map((recommendation) => (
-                  <RecommendedEvent
-                    key={recommendation.id}
-                    recommendation={recommendation}
-                    handleAccept={handleAccept} // Pass the new handleAccept
-                    currentRecommendations={currentRecommendations}
-                    setCurrentRecommendations={setCurrentRecommendations} // For handleDelete within RecommendedEvent
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      )}
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/assistant/messages/UserMessage.jsx
+++ b/src/components/assistant/messages/UserMessage.jsx
@@ -1,8 +1,23 @@
+import { store } from "../../../store/store.js";
+
 export function UserMessage({ message }) {
+  const { profileImageURL } = store();
+  const nickname = localStorage.getItem("nickname");
+
   return (
     <div className="my-2 flex justify-end">
-      <div className="bg-blue-600 text-white py-2 px-4 rounded-xl shadow-md max-w-md lg:max-w-lg break-words">
-        {message.data.message}
+      <div className="flex flex-col items-end">
+        <div className="flex items-center gap-x-2 mb-1">
+          <span className="font-semibold text-sm">{nickname}</span>
+          <img
+            src={profileImageURL}
+            className="w-5 h-5 rounded-full border"
+            alt="User"
+          />
+        </div>
+        <div className="bg-blue-600 text-white py-2 px-4 rounded-xl shadow-md max-w-md lg:max-w-lg break-words">
+          {message.data.message}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show user's profile photo in UserMessage
- display assistant logo and name in AssistantMessage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685cedd59290832cae28b080c05c841b