### PR TITLE
Expand chat layout for readability

### DIFF
--- a/src/components/assistant/Chat.jsx
+++ b/src/components/assistant/Chat.jsx
@@ -189,7 +189,7 @@ export function Chat(){
                         }
                     }}
                     placeholder="Ask me anything..."
-                    className="w-full h-full p-3 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 border border-slate-300 rounded-xl shadow-sm bg-white text-slate-700 placeholder-slate-400 text-sm"
+                    className="w-full h-full p-3 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 border border-slate-300 rounded-xl shadow-sm bg-white text-slate-700 placeholder-slate-400 text-base"
                 />
             </div>
         </>

--- a/src/components/assistant/ConversationContainer.jsx
+++ b/src/components/assistant/ConversationContainer.jsx
@@ -35,7 +35,7 @@ export function ConversationContainer() {
   // Assuming Greeting is roughly 20% of initial view, Chat input is roughly 15%.
   // When chat starts, Greeting becomes smaller.
   const greetingAreaHeightClass = isChatStarting ? "h-[30px]" : "h-[120px]"; // Fixed heights for more predictability
-  const chatInputAreaHeight = "h-[80px]"; // Fixed height for chat input area
+  const chatInputAreaHeight = "h-[100px]"; // Increased height for chat input area
 
   return (
     <div className="w-full h-full relative flex flex-col bg-slate-50">

--- a/src/components/assistant/messages/UserMessage.jsx
+++ b/src/components/assistant/messages/UserMessage.jsx
@@ -13,7 +13,7 @@ export function UserMessage({ message }) {
             alt="User"
           />
         </div>
-        <div className="bg-blue-600 text-white py-2 px-4 rounded-xl shadow-md max-w-md lg:max-w-lg break-words">
+        <div className="bg-blue-600 text-white py-2 px-4 rounded-xl shadow-md max-w-md lg:max-w-lg break-words text-base">
           {message.data.message}
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,8 @@ body {
 }
 
 #root{
-  height: 400px;
+  height: 600px;
+  width: 500px;
 }
 
 ::-webkit-scrollbar {

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -74,7 +74,7 @@ export default function Layout() {
   useEffect(profileBoxToggle, [openProfilBox]);
 
   return (
-    <div className="w-80 h-[400px] bg-white grid items-center justify-items-center grid-rows-[30px_30px_320px] gap-y-[15px]">
+    <div className="w-[450px] h-[560px] bg-white grid items-center justify-items-center grid-rows-[40px_40px_1fr] gap-y-[15px]">
       <header className="w-full h-full flex items-center justify-between">
         <div className="h-full flex">
           <img className="w-8 h-8" src={logo}></img>


### PR DESCRIPTION
## Summary
- enlarge app container size for better readability
- widen text area font size and chat input height

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5e2c3a1c832cbf831ff00e91a97e