### PR TITLE
Add event color store and update schedule design

### DIFF
--- a/src/components/schedule/Day.jsx
+++ b/src/components/schedule/Day.jsx
@@ -1,15 +1,10 @@
 import { schedulePageStore, monthNames } from "./schedulePageStore";
 import { useEffect, useState } from "react";
+import { eventCategoryStyles } from "../../store/store.js";
 
 export function Day({ day, month, events }) {
   const { setOpenModal, setSelectedDay } = schedulePageStore();
   const [isToday, setIsToday] = useState(false);
-  const divColorByCategory = {
-    Work: "bg-blue-400",
-    Personal: "bg-yellow-400",
-    Study: "bg-green-400",
-    Exercise: "bg-red-400",
-  };
 
   useEffect(() => {
     const today = new Date();
@@ -35,7 +30,7 @@ export function Day({ day, month, events }) {
         <div
           key={index}
           className={`w-full h-[3px] rounded-md mt-0.5 ${
-            divColorByCategory[event.event_category]
+            eventCategoryStyles[event.event_category]?.bg
           }`}
         ></div>
       ))}

--- a/src/components/schedule/DraggableDay.jsx
+++ b/src/components/schedule/DraggableDay.jsx
@@ -1,6 +1,7 @@
 import { schedulePageStore,monthNames } from "./schedulePageStore";
 import { useEffect, useState } from "react";
 import { useRef } from "react";
+import { eventCategoryStyles } from "../../store/store.js";
 
 export function DraggableDay({ day, month, events }) {
   const { isDragging, setIsDragging, setSelectedDays, selectedDays, currentIndex } =
@@ -8,12 +9,6 @@ export function DraggableDay({ day, month, events }) {
   const [isSelected, setIsSelected] = useState(false);
   const [isToday, setIsToday] = useState(false);
   const dayRef = useRef();
-  const divColorByCategory = {
-    Work: "bg-blue-400",
-    Personal: "bg-yellow-400",
-    Study: "bg-green-400",
-    Exercise: "bg-red-400",
-  };
 
   useEffect(() => {
     setIsSelected(false);
@@ -68,7 +63,7 @@ export function DraggableDay({ day, month, events }) {
         <div
           key={index}
           className={`w-full h-[3px] rounded-md mt-0.5 ${
-            divColorByCategory[event.event_category]
+            eventCategoryStyles[event.event_category]?.bg
           }`}
         ></div>
       ))}

--- a/src/components/schedule/Event.jsx
+++ b/src/components/schedule/Event.jsx
@@ -7,6 +7,7 @@ import editIconGray from "../../assets/pencil-gray.svg";
 import completeIcon from "../../assets/complete.svg";
 import { checkAuth } from "../../lib/lib.js";
 import { schedulePageStore } from "./schedulePageStore.js";
+import { eventCategoryStyles } from "../../store/store.js";
 
 export function Event({
     index,
@@ -20,16 +21,12 @@ export function Event({
     showCompleteIcon,
     showDeleteIcon,
   }) {
-    // Color and icon for category
-    const categoryColors = {
-      Work: "bg-blue-100 text-blue-700 border-blue-400",
-      Study: "bg-green-100 text-green-700 border-green-400",
-      Personal: "bg-yellow-100 text-yellow-700 border-yellow-400",
-      Exercise: "bg-red-100 text-red-700 border-red-400",
-    };
+    // classes for category label and borders
     const categoryClass =
-      categoryColors[eventCategory] ||
+      eventCategoryStyles[eventCategory]?.label ||
       "bg-gray-100 text-gray-700 border-gray-300";
+    const borderClass =
+      eventCategoryStyles[eventCategory]?.border || "border-gray-300";
   
     // For time icon
     const clockIcon = (
@@ -143,7 +140,7 @@ export function Event({
     return (
       <div
         key={index}
-        className={`w-full rounded-lg border ${categoryClass} shadow-sm p-3 mb-1 hover:shadow-lg transition-all flex flex-col items-start justify-start`}
+        className={`w-full rounded-md border-l-4 ${borderClass} bg-white shadow-sm p-3 mb-1 hover:shadow-md transition-all flex flex-col items-start justify-start`}
       >
         <div className="w-full flex items-center justify-between mb-1">
           {editing ? (

--- a/src/components/schedule/SetEvent.jsx
+++ b/src/components/schedule/SetEvent.jsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { checkAuth, fetchWithErrorHandling } from "../../lib/lib";
 import { monthNames } from "./schedulePageStore.js";
 import ErrorNotification from "../common/ErrorNotification";
+import { eventCategoryStyles } from "../../store/store.js";
 
 export function SetEvent({ setShowSetEvent, selectedDay, setTrigger }) {
   const navigate = useNavigate();
@@ -12,8 +13,8 @@ export function SetEvent({ setShowSetEvent, selectedDay, setTrigger }) {
   const [description, setDescription] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
-  const [categorySelectBorderColor, setCategorySelectBorderColor] =
-    useState("border-blue-400");
+  const borderClass =
+    eventCategoryStyles[eventCategory]?.border || "border-blue-400";
 
   const handleChangeValue = (e, setState) => {
     setState(e.target.value);
@@ -63,22 +64,6 @@ export function SetEvent({ setShowSetEvent, selectedDay, setTrigger }) {
     }
   };
 
-  useEffect(() => {
-    switch (eventCategory) {
-      case "Work":
-        setCategorySelectBorderColor("border-blue-400");
-        break;
-      case "Personal":
-        setCategorySelectBorderColor("border-yellow-400");
-        break;
-      case "Study":
-        setCategorySelectBorderColor("border-green-400");
-        break;
-      case "Exercise":
-        setCategorySelectBorderColor("border-red-400");
-        break;
-    }
-  }, [eventCategory]);
 
   return (
     <div className="bg-white p-2 rounded-lg w-full max-w-md">
@@ -125,7 +110,7 @@ export function SetEvent({ setShowSetEvent, selectedDay, setTrigger }) {
             <select
               value={eventCategory}
               onChange={(e) => setEventCategory(e.target.value)}
-              className={`border-2 ${categorySelectBorderColor} focus:outline-none focus:${categorySelectBorderColor} cursor-pointer rounded-md p-1`}
+              className={`border-2 ${borderClass} focus:outline-none cursor-pointer rounded-md p-1`}
             >
               <option value="Work">Work</option>
               <option value="Personal">Personal</option>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { checkAuth } from "../lib/lib.js";
+import { eventCategoryStyles } from "../store/store.js";
 
 export default function Home() {
   const navigate = useNavigate();
   const [todayEvents, setTodayEvents] = useState([]);
   const [suggestion, setSuggestion] = useState("");
+  const [lastSuggestion, setLastSuggestion] = useState(
+    localStorage.getItem("lastSuggestion") || ""
+  );
   const todayEventsStore = JSON.parse(localStorage.getItem("todayEvents"));
   const lastSuggestionTime = localStorage.getItem("lastSuggestionTime");
 
@@ -91,7 +95,15 @@ export default function Home() {
         const { data } = await response.json();
         if (response.ok) {
           setSuggestion(data.suggestion);
-          localStorage.setItem("lastSuggestionTime", new Date().toISOString().split("T")[1]);
+          setLastSuggestion(data.suggestion);
+          localStorage.setItem(
+            "lastSuggestion",
+            data.suggestion
+          );
+          localStorage.setItem(
+            "lastSuggestionTime",
+            new Date().toISOString().split("T")[1]
+          );
         }
       } catch (err) {
         console.error(err);
@@ -104,41 +116,42 @@ export default function Home() {
 
   }, []);
 
-  const categoryBorderColors = {
-    Work: "border-blue-400",
-    Study: "border-green-400",
-    Personal: "border-yellow-400",
-    Exercise: "border-red-400",
-  };
 
   return (
-    <div className="w-full h-full grid grid-rows-[1fr_1fr] gap-y-2">
-      <div className="w-full h-full p-2">
-
+    <div className="w-full h-full flex flex-col gap-y-3 p-2">
+      <div className="flex-1 w-full overflow-y-auto">
+        <div className="w-full h-full bg-blue-50 border border-blue-200 rounded-md shadow-sm p-3 flex flex-col">
+          <span className="font-semibold text-blue-700 text-sm mb-1">Suggestion</span>
+          <p className="text-sm text-gray-700 whitespace-pre-line flex-grow">
+            {suggestion || lastSuggestion || "No suggestions right now."}
+          </p>
+        </div>
       </div>
-      <div className="w-full h-full grid grid-rows-[10%_90%] items-center justify-items-start gap-y-2">
-        <span className="font-semibold text-sm">Today's Schedule</span>
-        <div className="w-full h-full flex flex-col gap-y-1 overflow-y-auto">
-          {todayEvents.length > 0 && (
-            <>
-            {todayEvents.map((event,index) => (
-            <div
+      <div className="flex-1 w-full flex flex-col overflow-y-auto">
+        <span className="font-semibold text-sm mb-1">Today's Schedule</span>
+        <div className="flex flex-col gap-y-2 overflow-y-auto">
+          {todayEvents.length > 0 ? (
+            todayEvents.map((event, index) => (
+              <div
                 key={index}
-                className={`p-2 rounded-md border-2 flex items-center justify-between hover:shadow-md transition-all ${categoryBorderColors[event.event_category] || "bg-gray-100 text-gray-700 border-gray-300"}`}
+                className={`p-2 rounded-md border-l-4 shadow-sm flex items-center justify-between bg-white ${eventCategoryStyles[event.event_category]?.border || "border-gray-300"}`}
               >
-              <span className="font-semibold text-sm">{event.title}</span>
-              <span className="text-xs text-gray-500">
-                {event.start_time ? event.start_time.slice(0, 5) : ""} -
-                {" "}
-                {event.end_time ? event.end_time.slice(0, 5) : ""}
-              </span>
-            </div>
-            ))}
-            </>
-          )}
-          {todayEvents.length === 0 && (
+                <div className="flex flex-col">
+                  <span className="font-semibold text-sm">{event.title}</span>
+                  {event.description && (
+                    <span className="text-xs text-gray-500 whitespace-pre-line">
+                      {event.description}
+                    </span>
+                  )}
+                </div>
+                <span className="text-xs text-gray-500">
+                  {event.start_time ? event.start_time.slice(0, 5) : ""} - {event.end_time ? event.end_time.slice(0, 5) : ""}
+                </span>
+              </div>
+            ))
+          ) : (
             <span className="font-semibold text-gray-500 text-sm">No events for today.</span>
-          )} 
+          )}
         </div>
       </div>
     </div>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -10,7 +10,30 @@ export const setState = (set,get,stateName,arg)=>{
     }
 }
 
+export const eventCategoryStyles = {
+    Work:{
+        border:"border-blue-400",
+        bg:"bg-blue-400",
+        label:"bg-blue-100 text-blue-700 border-blue-400"
+    },
+    Study:{
+        border:"border-green-400",
+        bg:"bg-green-400",
+        label:"bg-green-100 text-green-700 border-green-400"
+    },
+    Personal:{
+        border:"border-yellow-400",
+        bg:"bg-yellow-400",
+        label:"bg-yellow-100 text-yellow-700 border-yellow-400"
+    },
+    Exercise:{
+        border:"border-red-400",
+        bg:"bg-red-400",
+        label:"bg-red-100 text-red-700 border-red-400"
+    }
+};
+
 export const store = create((set,get)=>({
     profileImageURL:"",
-    setProfileImageURL:(arg)=>setState(set,get,"profileImageURL",arg),  
+    setProfileImageURL:(arg)=>setState(set,get,"profileImageURL",arg),
 }))


### PR DESCRIPTION
## Summary
- centralize event category colors in store
- apply consistent border design to schedule events
- update SetEvent, Day, and DraggableDay to read colors from store
- use stored colors on Home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ebaca2cbc832c9ba0852bfdbee431